### PR TITLE
Add handling of non-YAML files in decoder

### DIFF
--- a/src/xchemalign/decoder/decoder.py
+++ b/src/xchemalign/decoder/decoder.py
@@ -89,8 +89,10 @@ def validate_assemblies_schema(assembly_filename: str) -> str | None:
     try:
         with open(assembly_filename, "r", encoding="utf8") as assembly_file:
             assembly: dict[str, Any] = yaml.load(assembly_file, DupCheckLoader)
-    except yaml.constructor.ConstructorError as cex:
-        return str(cex)
+    except yaml.constructor.ConstructorError as ce:
+        return str(ce)
+    except yaml.scanner.ScannerError:
+        return f"Unable to understand the assembly file '{assembly_filename}'. Is it valid YAML?"
 
     try:
         jsonschema.validate(assembly, schema=_ASSEMBLIES_SCHEMA)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,7 @@ import shutil
 import yaml
 import pytest
 
-from ligand_neighbourhood_alignment import dt
+#from ligand_neighbourhood_alignment import dt
 
 
 @pytest.fixture(scope="session")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,7 @@ import shutil
 import yaml
 import pytest
 
-#from ligand_neighbourhood_alignment import dt
+from ligand_neighbourhood_alignment import dt
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_assemblies_decoder.py
+++ b/tests/test_assemblies_decoder.py
@@ -1,12 +1,23 @@
 from xchemalign.decoder import decoder
 
 
-def test_with_missigg_file():
+def test_with_missing_file():
     # Arrange
     expected_error = "The assembly file 'no-such-file.yaml' does not exist"
 
     # Act
     error = decoder.validate_assemblies_schema("no-such-file.yaml")
+
+    # Assert
+    assert error == expected_error
+
+
+def test_with_non_yaml_file():
+    # Arrange
+    expected_error = "Unable to understand the assembly file 'test-data/README.txt'. Is it valid YAML?"
+
+    # Act
+    error = decoder.validate_assemblies_schema("test-data/README.txt")
 
     # Assert
     assert error == expected_error


### PR DESCRIPTION
- better handling of really badly formatted files (i.e. those that are not YAML)