### PR TITLE
Add --force-superseded collator option (issue #87)

### DIFF
--- a/docs/source/USER-GUIDE.md
+++ b/docs/source/USER-GUIDE.md
@@ -437,6 +437,23 @@ covalent: true
 There was previously a mechanism to manually override the status of any crystal. This feature has now been removed.
 Instead you should set the status is soakDB to `7 - Analysed & Rejected`.
 
+#### Forcing structures into an upload
+
+By default the collator decides each crystal's status by comparing the SHA256 of its PDB file against the previous
+version: if the PDB is unchanged the crystal is marked `unchanged` and is left out of the next upload (it keeps its
+previous version in Fragalysis and is not re-aligned).
+
+Sometimes something that matters changes without the PDB file changing — for example an edit to `assemblies.yaml`. In
+that situation you can force all otherwise-`unchanged` crystals to `superseded` status for a single run so that they are
+re-processed and included in the next upload:
+
+```
+python -m xchemalign.collator -d <working_dir> --force-superseded
+```
+
+This flag applies only to the run in which it is given. Crystals that are `new` remain `new`, and crystals that have
+been rejected in soakDB remain `deprecated`.
+
 ### 2.3. The assemblies YAML
 
 This file specifies both the biological *assemblies* and *crystalforms* relative to some reference PDBs.

--- a/src/xchemalign/collator.py
+++ b/src/xchemalign/collator.py
@@ -141,12 +141,13 @@ class Input:
 
 
 class Collator:
-    def __init__(self, working_dir, include_git_info=False, no_validate_configs=False):
+    def __init__(self, working_dir, include_git_info=False, no_validate_configs=False, force_superseded=False):
         self.errors = []
         self.warnings = []
 
         self.include_git_info = include_git_info
         self.no_validate_configs = no_validate_configs
+        self.force_superseded = force_superseded
 
         self.working_dir = Path(working_dir)
         self.output_path = self.working_dir / "upload-current"
@@ -933,8 +934,8 @@ class Collator:
                         # do any chain renaming here
                         digest = utils.gen_sha256(pdb_input)
                         old_digest = historical_xtal_data.get(Constants.META_XTAL_PDB, {}).get(Constants.META_SHA256)
-                        if digest != old_digest:
-                            # PDB is new or changed
+                        if digest != old_digest or self.force_superseded:
+                            # PDB is new or changed (or being force-superseded)
                             if old_digest is not None:
                                 self.logger.info("PDB file for {} has changed".format(xtal_name))
                             pdb_name = xtal_name + ".pdb"
@@ -951,7 +952,7 @@ class Collator:
                             old_digest = historical_xtal_data.get(Constants.META_XTAL_MTZ, {}).get(
                                 Constants.META_SHA256
                             )
-                            if digest != old_digest:
+                            if digest != old_digest or self.force_superseded:
                                 if old_digest is not None:
                                     self.logger.info("MTZ file for {} has changed".format(xtal_name))
                                 mtz_name = xtal_name + ".mtz"
@@ -974,7 +975,7 @@ class Collator:
                             old_digest = historical_xtal_data.get(Constants.META_XTAL_CIF, {}).get(
                                 Constants.META_SHA256
                             )
-                            if digest != old_digest:
+                            if digest != old_digest or self.force_superseded:
                                 if old_digest is not None:
                                     self.logger.info("CIF file for {} has changed".format(xtal_name))
                                 cif_name = xtal_name + ".cif"
@@ -1037,7 +1038,7 @@ class Collator:
                                 hist_data = hist_event_maps.get(ligand_key)
                                 # Track whether the event map actually is new by data
                                 if hist_data:
-                                    if digest == hist_data.get(Constants.META_SHA256):
+                                    if digest == hist_data.get(Constants.META_SHA256) and not self.force_superseded:
                                         identical_historical_event_maps[ligand_key] = True
                                         self.logger.info(
                                             "Event map {} for {} is unchanged".format(ligand_key, xtal_name)
@@ -1323,6 +1324,11 @@ class Collator:
         # get any user defined overrides
         overrides = self.config.get(Constants.CONFIG_OVERRIDES, {})
 
+        if self.force_superseded:
+            self.logger.info(
+                "--force-superseded is set: crystals that would be 'unchanged' will be forced to 'superseded'"
+            )
+
         count = 0
         for metad in self.meta_history:
             count += 1
@@ -1383,6 +1389,8 @@ class Collator:
         old_sha256 = old_pdb_data[Constants.META_SHA256]
         new_sha256 = new_pdb_data[Constants.META_SHA256]
         if old_sha256 == new_sha256:
+            if self.force_superseded:
+                return Constants.META_STATUS_SUPERSEDED
             return Constants.META_STATUS_UNCHANGED
         else:
             return Constants.META_STATUS_SUPERSEDED
@@ -1505,6 +1513,13 @@ def main():
         action="store_true",
         help="Don't validate config.yaml and assemblies.yaml against their schemas",
     )
+    parser.add_argument(
+        "-f",
+        "--force-superseded",
+        action="store_true",
+        help="Force all otherwise-unchanged crystals to 'superseded' status so they are "
+        "re-processed and included in the next upload (use when non-PDB inputs changed)",
+    )
 
     args = parser.parse_args()
 
@@ -1535,6 +1550,7 @@ def main():
             working_dir,
             include_git_info=args.no_git_info,
             no_validate_configs=args.no_validate_configs,
+            force_superseded=args.force_superseded,
         )
 
         if logger.errors:

--- a/tests/test_collator_status.py
+++ b/tests/test_collator_status.py
@@ -1,0 +1,42 @@
+from xchemalign.collator import Collator
+from xchemalign.utils import Constants
+
+
+def _make_collator(force_superseded=False, rejected_xtals=None):
+    # bypass the heavy __init__ (config/working dir); exercise only _get_xtal_status
+    c = Collator.__new__(Collator)
+    c.force_superseded = force_superseded
+    c.rejected_xtals = rejected_xtals or set()
+    return c
+
+
+def _xtal_data(sha256):
+    return {Constants.META_XTAL_FILES: {Constants.META_XTAL_PDB: {Constants.META_SHA256: sha256}}}
+
+
+def test_status_unchanged_when_pdb_identical():
+    c = _make_collator()
+    old = _xtal_data("aaa")
+    new = _xtal_data("aaa")
+    assert c._get_xtal_status("xtal-1", old, new) == Constants.META_STATUS_UNCHANGED
+
+
+def test_status_superseded_when_pdb_differs():
+    c = _make_collator()
+    old = _xtal_data("aaa")
+    new = _xtal_data("bbb")
+    assert c._get_xtal_status("xtal-1", old, new) == Constants.META_STATUS_SUPERSEDED
+
+
+def test_force_superseded_promotes_unchanged():
+    c = _make_collator(force_superseded=True)
+    old = _xtal_data("aaa")
+    new = _xtal_data("aaa")
+    assert c._get_xtal_status("xtal-1", old, new) == Constants.META_STATUS_SUPERSEDED
+
+
+def test_rejected_xtal_stays_deprecated_regardless_of_force():
+    c = _make_collator(force_superseded=True, rejected_xtals={"xtal-1"})
+    old = _xtal_data("aaa")
+    new = _xtal_data("aaa")
+    assert c._get_xtal_status("xtal-1", old, new) == Constants.META_STATUS_DEPRECATED

--- a/tests/test_force_superseded.py
+++ b/tests/test_force_superseded.py
@@ -1,0 +1,107 @@
+"""
+Integration test for the collator's ``--force-superseded`` option (issue #87).
+
+Scenario:
+  * upload_1 is run with one dataset (Mpro-IBM0078) excluded.
+  * upload_2 is run with that dataset included and with ``force_superseded=True``.
+
+Expected outcome:
+  * the previously excluded dataset appears in upload_2 with status ``new``;
+  * datasets present in both uploads (unchanged PDB) are forced to status ``superseded``;
+  * the forced datasets have their crystallographic files re-copied into the upload_2
+    directory and their metadata file paths point at upload_2 (not the previous upload).
+"""
+
+import os
+import shutil
+from pathlib import Path
+
+import yaml
+
+from xchemalign.collator import Collator
+from xchemalign.utils import Constants
+
+
+# dataset excluded from upload_1 then re-introduced in upload_2 -> should become "new"
+EXCLUDED_DATASET = "Mpro-IBM0078"
+# datasets present (unchanged) in both uploads -> forced to "superseded" in upload_2
+UNCHANGED_DATASETS = ["Mpro-IBM0045", "Mpro-IBM0058"]
+
+
+def _read_meta(upload_dir: Path) -> dict:
+    with open(upload_dir / Constants.METADATA_XTAL_FILENAME.format("")) as f:
+        return yaml.safe_load(f)
+
+
+def _setup_working_dir(tmp_path: Path, exclude: list[str]) -> tuple[Path, Path]:
+    """Create a working dir with an upload-current symlink, assemblies.yaml and a config.yaml.
+
+    The config is based on test-data/config_1.yaml; ``exclude`` is applied to the
+    model_building input. Returns (working_dir, version_dir).
+    """
+    version_dir = tmp_path / "upload-v3"
+    (version_dir / "upload_1").mkdir(parents=True)
+    os.symlink(version_dir, tmp_path / "upload-current", target_is_directory=True)
+
+    shutil.copy("test-data/assemblies.yaml", version_dir / "assemblies.yaml")
+
+    with open("test-data/config_1.yaml") as f:
+        config = yaml.safe_load(f)
+    # first input is the model_building input containing Mpro-IBM0078
+    config["inputs"][0][Constants.CONFIG_EXCLUDE] = list(exclude)
+    with open(version_dir / "config.yaml", "w") as f:
+        yaml.dump(config, f, sort_keys=False)
+
+    return tmp_path, version_dir
+
+
+def _run_collator(working_dir: Path, force_superseded: bool):
+    c = Collator(str(working_dir), no_validate_configs=True, force_superseded=force_superseded)
+    meta = c.validate()
+    assert meta is not None and len(c.logger.errors) == 0, c.logger.errors
+    c.run(meta)
+
+
+def test_force_superseded_status_and_files(tmp_path):
+    working_dir, version_dir = _setup_working_dir(tmp_path, exclude=[EXCLUDED_DATASET])
+
+    # --- upload_1: excluded dataset absent, everything else is "new" ---
+    _run_collator(working_dir, force_superseded=False)
+
+    meta_1 = _read_meta(version_dir / "upload_1")
+    xtals_1 = meta_1[Constants.META_XTALS]
+    assert EXCLUDED_DATASET not in xtals_1
+    for dataset in UNCHANGED_DATASETS:
+        assert xtals_1[dataset][Constants.META_STATUS] == Constants.META_STATUS_NEW
+
+    # --- upload_2: drop the exclusion and force superseded ---
+    # remove the exclude from the config, then create the new (empty) upload_2 dir
+    with open(version_dir / "config.yaml") as f:
+        config = yaml.safe_load(f)
+    del config["inputs"][0][Constants.CONFIG_EXCLUDE]
+    with open(version_dir / "config.yaml", "w") as f:
+        yaml.dump(config, f, sort_keys=False)
+    (version_dir / "upload_2").mkdir()
+
+    _run_collator(working_dir, force_superseded=True)
+
+    meta_2 = _read_meta(version_dir / "upload_2")
+    xtals_2 = meta_2[Constants.META_XTALS]
+
+    # the re-introduced dataset is brand new
+    assert xtals_2[EXCLUDED_DATASET][Constants.META_STATUS] == Constants.META_STATUS_NEW
+
+    # datasets whose PDB did not change are forced to superseded ...
+    for dataset in UNCHANGED_DATASETS:
+        assert xtals_2[dataset][Constants.META_STATUS] == Constants.META_STATUS_SUPERSEDED
+
+        # ... and their files are re-copied into upload_2 with metadata pointing there
+        pdb_entry = xtals_2[dataset][Constants.META_XTAL_FILES][Constants.META_XTAL_PDB]
+        pdb_file = pdb_entry[Constants.META_FILE]
+        assert pdb_file.startswith("upload_2/"), pdb_file
+        assert (version_dir / pdb_file).is_file()
+
+    # the new dataset's files also live under upload_2
+    new_pdb_file = xtals_2[EXCLUDED_DATASET][Constants.META_XTAL_FILES][Constants.META_XTAL_PDB][Constants.META_FILE]
+    assert new_pdb_file.startswith("upload_2/"), new_pdb_file
+    assert (version_dir / new_pdb_file).is_file()


### PR DESCRIPTION
Closes #87.

## What

Adds a per-run `--force-superseded` flag to the collator that forces every crystal which would otherwise be `unchanged` to `superseded` status, so it is re-processed and included in the next upload.

This is needed when something that matters has changed but the PDB files have not — for example an edit to `assemblies.yaml`. Normally such crystals are marked `unchanged` (based on a PDB SHA256 comparison), left out of the upload, and skipped by the aligner.

## How

The flag is honoured in two places:

- **`_get_xtal_status`** — an otherwise-`unchanged` crystal is promoted to `superseded`. `new` crystals stay `new`; rejected crystals stay `deprecated`.
- **`_copy_files`** — the PDB/MTZ/CIF/event-map copy decisions (previously driven solely by per-file SHA256 comparison, independent of status) also honour the flag, so the forced entries have their files re-copied into the current version dir and their metadata paths updated. Without this, the status flipped to `superseded` but the files stayed in the previous upload and the metadata kept pointing there.

## Tests

- `tests/test_collator_status.py` — unit tests for `_get_xtal_status` (unchanged / superseded / force-promoted / rejected-stays-deprecated).
- `tests/test_force_superseded.py` — integration test: excludes a dataset from upload_1, re-introduces it in upload_2 with `force_superseded=True`, and asserts the resulting status values, metadata file paths (`upload_2/...`) and that the files were actually copied.

Full suite: 70 passed.

## Docs

`docs/source/USER-GUIDE.md` gains a "Forcing structures into an upload" subsection documenting the flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)